### PR TITLE
Added mTLS to mqtt connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,43 @@ An installation of **mqtt-panel** will need a MQTT broker to connect to. There a
 
 ```
 mqtt:
-  host: <host>                  # optional: MQTT broker host, default: 127.0.0.1
-  port: <port>                  # optional: MQTT broker port, default 1883
-  username: <string>            # optional: MQTT broker username
-  password: <string>            # optional: MQTT password username
-  client-id: mqtt-panel         # MQTT client identifier, often brokers require this to be unique
-  topic-prefix: <topic prefix>  # optional: Scopes the MQTT topic prefix
+  host: <host>                        # optional: MQTT broker host, default: 127.0.0.1
+  port: <port>                        # optional: MQTT broker port, default 1883
+  client-id: mqtt-panel               # MQTT client identifier, often brokers require this to be unique
+  topic-prefix: <topic prefix>        # optional: Scopes the MQTT topic prefix
+  auth:                               # optional: Defines the authentication used to connect to the MQTT broker
+    type: 'none' | 'basic' | 'mtls'   # type of authentication ('none', 'basic', 'mtls')
+    ... (type-specific options -- see below)
+```
+```
+# mqtt explict no-authentication
+mqtt:
+  ...
+  auth:
+    type: 'none'
+```
+```
+# mqtt basic authentication
+mqtt:
+  ...
+  auth:
+    type: 'basic'
+    username: <string>          # optional: MQTT broker username
+    password: <string>          # optional: MQTT broker password
+```
+```
+# mqtt mutual-tls authentication
+mqtt:
+  ...
+  auth:
+    type: 'mtls'
+    # hint: if running in a container, use the container-relevant-paths for the following files
+    cafile: <string>            # path to the CA file used to verify the server
+    certfile: <string>          # path to the certificate presented by this client
+    keyfile: <string>           # path to the private-key presented by this client
+    keyfile_password: <string>  # optional: password used to decrypt the `keyfile`
+    protocols:                  # optional: list of ALPN protocols to add to the SSL connection
+      - <string>
 ```
 ```
 http:

--- a/mqtt_panel/util.py
+++ b/mqtt_panel/util.py
@@ -97,3 +97,16 @@ def blob_hash(blob):
 
 def pad_string(msg, length, ch):
     return msg + (ch * (length - len(msg)))
+
+
+def validate_path(path: str) -> None:
+    """validate if the given path exists
+
+    Args:
+        path (str): the path to validate
+
+    Raises:
+        ValueError: if the path does not exist
+    """
+    if not os.path.exists(path):
+        raise ValueError(f'Invalid path: {path}')


### PR DESCRIPTION
I was looking to try out your panel for my use case and I needed mutual-TLS (authentication with certificates). Here's an implementation with mTLS if you're interested in pulling it in. I did change the way `auth` is defined under the `mqtt` key.

Was:
```yaml
mqtt:
  ...
  username: 'something'
  password: 'something'
  ...
```

Now:
```yaml
mqtt:
  ...
  auth:
    type: 'basic'
    username: 'something'
    password: 'something'
```

I tried maintaining backwards compatibility, but I didn't test the basic auth.

While adding this feature, I also noticed that the handlers didn't support MQTT topic patterns (with `+` and `#`) so I added that as well.